### PR TITLE
Segregate NSG into separate deployment

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,8 +4,8 @@ Attribution-ShareAlike 4.0 International License.
 
 CC-BY-SA 4.0 License
 -----------------
-This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 
+This work is licensed under a Creative Commons Attribution-ShareAlike 4.0
 International License.
 
 You should have received a copy of the license along with this
-work (see CC-BY-SA-4.txt). If not, see <https://creativecommons.org/licenses/by-sa/4.0/legalcode>.
+work (see [CC-BY-SA-4.txt](CC-BY-SA-4.txt)). If not, see <https://creativecommons.org/licenses/by-sa/4.0/legalcode>.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-# Linux Cluster with LB
-
+# Load-balanced Linux Cluster
 This repository contains Azure templates to deploy a load-balanced Linux-based
-generic cluster in Microsoft Azure Recourses Manager (ARM).
+generic cluster in Microsoft Azure Recourses Manager (ARM). It also has
+[cisco-csr1000v.json](cisco-csr1000v.json) template for deployment of Cisco
+CSR-1000v virtual router to build VPN tunnels to the environment.
 
 ## Getting Started
+```
+/usr/bin/az group deployment create \
+  --resource-group "RG-NAME" \
+  --name "DEPLOYMENT-NAME" \
+  --template-uri "https://raw.githubusercontent.com/ParanoidRat/azure-linux-lb/master/main.json" \
+  --parameters "@/path/to/params.json"
+```
 
-## Parameters
+## Parameters: Main template
 ```json
 "templateBaseUrl": {"value": "https://raw.githubusercontent.com/ParanoidRat/azure-linux-lb/master"},
 "vmNamespace": { "value": "fustercluck" },
@@ -34,20 +42,13 @@ generic cluster in Microsoft Azure Recourses Manager (ARM).
   "imageSKU": "16.04-LTS",
 
   "adminUsername": "<USER-NAME>",
-  "sshPublicKey": "ssh-rsa <SSH-PUB-KEY>",
-
-  "sshPort": "22"
+  "sshPublicKey": "ssh-rsa <SSH-PUB-KEY>"
 } },
 
 "netConfig": { "value": {
   "networkApiVersion": "2017-06-01",
 
   "publicIPAddressType": "Static",
-
-  "sshAllowedFrom": [
-    "8.8.8.8/32",
-    "4.4.4.4/32"
-  ],
 
   "vNetName": "<VNET-NAME>",
   "vNetAddressPrefix": "10.0.0.0/16",
@@ -56,25 +57,113 @@ generic cluster in Microsoft Azure Recourses Manager (ARM).
     {
       "name": "subnet-ext",
       "prefix": "10.0.1.0/24",
-      "allocateFrom":"10.0.1.4"
     },
     {
       "name": "subnet-int",
       "prefix": "10.0.2.0/24",
-      "allocateFrom":"10.0.2.4"
     }
-  ]
+  ],
+
+  "networkSecurityRules": [
+    {
+      "ruleName": "SSH-HOST01",
+      "ruleDescription": "Allows inbound SSH from specific host",
+      "ruleProtocol": "Tcp",
+      "ruleSourcePortRange": "*",
+      "ruleDestinationPortRange": "22",
+      "ruleSourceAddressPrefix": "8.8.8.8/32",
+      "ruleDestinationAddressPrefix": "*",
+    },
+    {
+      "ruleName": "SSH-HOST02",
+      "ruleDescription": "Allows inbound SSH from specific host",
+      "ruleProtocol": "Tcp",
+      "ruleSourcePortRange": "*",
+      "ruleDestinationPortRange": "22",
+      "ruleSourceAddressPrefix": "4.4.4.4/32",
+      "ruleDestinationAddressPrefix": "*",
+    },
+  ],
 } }
-}
+```
+
+## Parameters: Cisco CSR 1000v template
+```json
+"vmNamespace": { "value": "vpn" },
+
+"vmConfig": { "value": {
+  "computeApiVersion": "2017-03-30",
+
+  "vmName": "cisco-csr",
+
+  "vmSize": "Standard_DS2",
+
+  "osManagedDiskType": "Premium_LRS",
+  "osManagedDiskCache": "ReadWrite",
+
+  "tags": {
+    "Environment": "Development"
+  },
+
+  "imagePublisher": "cisco",
+  "imageOffer": "cisco-csr-1000v",
+  "imageSKU": "16_6",
+
+  "adminUsername": "<USER-NAME>",
+  "sshPublicKey": "ssh-rsa <SSH-PUB-KEY>"
+} },
+
+"netConfig": { "value": {
+  "networkApiVersion": "2017-06-01",
+
+  "publicIPAddressType": "Static",
+
+  "vNetRGName": "<RG-WITH-EXISTING-VNET>",
+
+  "vNetName": "<VNET-NAME>",
+  "vNetAddressPrefix": "10.0.0.0/16",
+
+  "vNetSubnets": [
+    {
+      "name": "subnet-ext",
+      "prefix": "10.0.1.0/24",
+    },
+    {
+      "name": "subnet-int",
+      "prefix": "10.0.2.0/24",
+    }
+  ],
+
+  "networkSecurityRules": [
+    {
+      "ruleName": "SSH-HOST01",
+      "ruleDescription": "Allows inbound SSH from specific host",
+      "ruleProtocol": "Tcp",
+      "ruleSourcePortRange": "*",
+      "ruleDestinationPortRange": "22",
+      "ruleSourceAddressPrefix": "8.8.8.8/32",
+      "ruleDestinationAddressPrefix": "*",
+    },
+    {
+      "ruleName": "SSH-HOST02",
+      "ruleDescription": "Allows inbound SSH from specific host",
+      "ruleProtocol": "Tcp",
+      "ruleSourcePortRange": "*",
+      "ruleDestinationPortRange": "22",
+      "ruleSourceAddressPrefix": "4.4.4.4/32",
+      "ruleDestinationAddressPrefix": "*",
+    },
+  ],
+    } }
 ```
 
 ## Authors
--   [**ParanoidRat**] [1]
+-   [**ParanoidRat**][1]
 
 ## License
 The work is licensed under the CC-BY-SA 4.0 License. Unless otherwise stated,
 modifications are also licensed under the CC-BY-SA 4.0 License. See the
-[LICENSE.txt](LICENSE.txt) file for details and specific licensing of the
+[LICENSE.md](LICENSE.md) file for details and specific licensing of the
 modifications.
 
 You should have received a copy of the license along with this work

--- a/main.json
+++ b/main.json
@@ -156,7 +156,7 @@
         },
         "protocol": "tcp",
         "frontendPort": "[copyIndex(variables('natStartPort'))]",
-        "backendPort": "[parameters('vmConfig').sshPort]",
+        "backendPort": "22",
         "enableFloatingIP": false
       }
     },

--- a/main.json
+++ b/main.json
@@ -177,10 +177,12 @@
             "value": "[parameters('templateBaseUrl')]"
           },
           "secConfig": {
-            "networkApiVersion": "[variables('networkApiVersion')]",
-            "secNamespace": "[parameters('vmNamespace')]",
-            "secCount": "[parameters('vmCount')]",
-            "secRules": "[parameters('netConfig').networkSecurityRules]"
+            "value": {
+              "networkApiVersion": "[variables('networkApiVersion')]",
+              "secNamespace": "[parameters('vmNamespace')]",
+              "secCount": "[parameters('vmCount')]",
+              "secRules": "[parameters('netConfig').networkSecurityRules]"
+            }
           }
         }
       }

--- a/main.json
+++ b/main.json
@@ -195,6 +195,7 @@
       "name": "[concat(parameters('vmNamespace'), copyIndex(), '-nic')]",
       "location": "[variables('location')]",
       "dependsOn": [
+        "[concat(parameters('vmNamespace'), '-nested-nsg')]",
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'), '/inboundNatRules/', 'SSH-NAT0', copyIndex())]"
       ],

--- a/main.json
+++ b/main.json
@@ -178,7 +178,7 @@
           },
           "secConfig": {
             "networkApiVersion": "[variables('networkApiVersion')]",
-            "secNamespace": "[concat(parameters('vmNamespace')]",
+            "secNamespace": "[parameters('vmNamespace')]",
             "secCount": "[parameters('vmCount')]",
             "secRules": "[parameters('netConfig').networkSecurityRules]"
           }

--- a/main.json
+++ b/main.json
@@ -46,6 +46,7 @@
       "Disabled": "[concat(parameters('templateBaseUrl'), '/vm-datadisks-disabled.json')]"
     },
     "templateVmUrl": "[variables('configHashVm')[parameters('vmConfig').dataManagedDiskEnabledOrDisabled]]",
+    "templateNsgUrl": "[concat(parameters('templateBaseUrl'), '/net-security.json')]",
     "clusterName": "[concat(parameters('vmNamespace'), '-cluster')]",
     "availabilitySetName":"[concat(parameters('vmNamespace'), '-avs')]",
     "publicIPAddressName": "[concat(parameters('vmNamespace'), '-ip')]",
@@ -160,33 +161,28 @@
       }
     },
     {
+      "name": "[concat(parameters('vmNamespace'), '-nested-nsg')]",
+      "type": "Microsoft.Resources/deployments",
       "apiVersion": "[variables('networkApiVersion')]",
-      "copy": {
-        "name": "[concat(parameters('vmNamespace'), '-loop-nsg')]",
-        "count": "[parameters('vmCount')]"
-      },
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[concat(parameters('vmNamespace'), copyIndex(), '-nsg')]",
-      "location": "[variables('location')]",
+      "dependsOn": [
+      ],
       "properties": {
-        "copy": [{
-          "name": "securityRules",
-          "count": "[length(parameters('netConfig').sshAllowedFrom)]",
-          "input": {
-            "name": "[concat('SSH-HOST0', copyIndex('securityRules', 1))]",
-            "properties": {
-              "description": "Allows inbound SSH from specific host",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "[parameters('vmConfig').sshPort]",
-              "sourceAddressPrefix": "[parameters('netConfig').sshAllowedFrom[copyIndex('securityRules')]]",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": "[mul(copyIndex('securityRules', 1), 100)]",
-              "direction": "Inbound"
-            }
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('templateNsgUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "templateBaseUrl": {
+            "value": "[parameters('templateBaseUrl')]"
+          },
+          "secConfig": {
+            "networkApiVersion": "[variables('networkApiVersion')]",
+            "secNamespace": "[concat(parameters('vmNamespace')]",
+            "secCount": "[parameters('vmCount')]",
+            "secRules": "[parameters('netConfig').networkSecurityRules]"
           }
-        }]
+        }
       }
     },
     {
@@ -238,7 +234,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[variables('templateVmURL')]",
+          "uri": "[variables('templateVmUrl')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/net-security.json
+++ b/net-security.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "templateBaseUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "Base uri for nested templates"
+      }
+    },
+    "secConfig": {
+      "type": "object",
+      "metadata": {
+        "description": "Structure with config for NSGs"
+      }
+    }
+  },
+  "variables": {
+  },
+  "resources": [
+    {
+      "apiVersion": "[parameters('secConfig').networkApiVersion]",
+      "copy": {
+        "name": "[concat(parameters('secConfig').secNamespace, '-loop-nsg')]",
+        "count": "[parameters('secConfig').secCount]"
+      },
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[concat(parameters('secConfig').secNamespace, copyIndex(), '-nsg')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "copy": [{
+          "name": "securityRules",
+          "count": "[length(parameters('secConfig').secRules)]",
+          "input": {
+            "name": "[concat(parameters('secConfig').secRules[copyIndex('securityRules')].ruleName)]",
+            "properties": {
+              "description": "[concat(parameters('secConfig').secRules[copyIndex('securityRules')].ruleDescription)]",
+              "protocol": "[concat(parameters('secConfig').secRules[copyIndex('securityRules')].ruleProtocol)]",
+              "sourcePortRange": "[concat(parameters('secConfig').secRules[copyIndex('securityRules')].ruleSourcePortRange)]",
+              "destinationPortRange": "[concat(parameters('secConfig').secRules[copyIndex('securityRules')].ruleDestinationPortRange)]",
+              "sourceAddressPrefix": "[concat(parameters('secConfig').secRules[copyIndex('securityRules')].ruleSourceAddressPrefix)]",
+              "destinationAddressPrefix": "[concat(parameters('secConfig').secRules[copyIndex('securityRules')].ruleDestinationAddressPrefix)]",
+              "access": "Allow",
+              "priority": "[mul(copyIndex('securityRules', 1), 100)]",
+              "direction": "Inbound"
+            }
+          }
+        }]
+      }
+    }
+  ],
+  "outputs": {
+  }
+}


### PR DESCRIPTION
Encapsulation of the Network Security Groups (NSGs) deployment into separate template enables code reuse and allows different name-spaces within one generalized deployment (e.g. vmA1-nsg, vmA2-nsg, ..., vmB1-nsg, vmB2-nsg, ..., subnet1-nsg, subnet2-nsg, etc)